### PR TITLE
LIBFCREPO-1072. Updated repository for new Plant Patents update process

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,8 @@
 # Ignore the data directory
 data
 uploads
+
+# Ignore files created by the Plant Patents update procedura
+fcrepo_urls.csv
+file_metadata.csv
+scans_metadata.csv

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,3 +1,11 @@
+# Dockerfile for the solr-plant-patents Docker image
+#
+# To build:
+#
+# docker build -t docker.lib.umd.edu/solr-plant-patents:<VERSION> -f Dockerfile .
+#
+# where <VERSION> is the Docker image version to create.
+
 FROM docker.lib.umd.edu/csv-validator:1.1.5-umd-0 as validator
 
 # Add the files
@@ -43,7 +51,7 @@ RUN /opt/solr/bin/solr start && sleep 3 && \
     curl -v "http://localhost:8983/solr/plant-patents/update/csv?commit=true&f.inventor.split=true&f.inventor.separator=;&f.city.split=true&f.city.separator=;&f.state.split=true&f.state.separator=;&f.country.split=true&f.country.separator=;" \
     --data-binary @/tmp/data.csv -H 'Content-type:text/csv; charset=utf-8' && \
     /opt/solr/bin/solr stop
-    
+
 FROM solr:8.11.0-slim@sha256:530547ad87f3fb02ed9fbbdbf40c0bfbfd8a0b472d8fea5920a87ec65aaacaef
 
 ENV SOLR_HOME=/apps/solr/data

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,3 +1,11 @@
+FROM docker.lib.umd.edu/csv-validator:1.1.5-umd-0 as validator
+
+# Add the files
+COPY data.csv /tmp/data.csv
+COPY data.csvs /tmp/data.csvs
+
+RUN validate /tmp/data.csv /tmp/data.csvs
+
 FROM solr:8.11.0@sha256:f9f6eed52e186f8e8ca0d4b7eae1acdbb94ad382c4d84c8220d78e3020d746c6 as builder
 
 # Switch to root user
@@ -27,7 +35,7 @@ RUN /opt/solr/bin/solr start && \
 COPY conf /apps/solr/data/plant-patents/conf/
 
 # Add the data to be loaded
-ADD data.csv /tmp/data.csv
+COPY --from=validator /tmp/data.csv /tmp/data.csv
 
 # Load the data to plant-patents core
 RUN /opt/solr/bin/solr start && sleep 3 && \

--- a/README.md
+++ b/README.md
@@ -2,12 +2,47 @@
 
 ## Introduction
 
-Note: Previous versions of this repository were used as a Solr configuration
-directory on solr.lib.umd.edu. This repository has now been changed to support
-creating a Docker image containing the data.
+This repository contains the data and tools needed to generate a
+"solar-plant-patents" Docker image, consisting of a Solr core populated with
+metadata from the Plant Patents Digitization Project.
 
 When making updates to the data or configuration, a new Docker image should be
 created.
+
+## data.csv File
+
+The "data.csv" file contains both "publishable" and "work-in-progess" records
+derived from the Plant Patents metadata provided by STEM. See the
+"plant-patents-ingest" repository
+<https://github.com/umd-lib/plant-patents-ingest>) for information on generating
+this file.
+
+As part of the Docker build, the "work-in-progress" records will be filtered
+out (using the "filter_for_publication" command from "plant-patents-ingest"),
+so the actual number of records in the Solr database will likely be fewer.
+
+**Note:** The "data.csv" file should not be "hand-edited", as it is updated
+using automatic processes.
+
+## CSV Schema Files
+
+The following files use the "CSV Schema Language v1.1"
+(<https://digital-preservation.github.io/csv-schema/csv-schema-1.1.html>) to
+verify the data files used for generating the Solr code:
+
+* patents_metadata.csvs: Validates the "patents_metadata.csv" file provided by
+   STEM. The validation of the "patents_metadata.csv" file occurs outside the
+   Docker build.
+* data.csvs: Validates the raw "data.csv" file containing both "publishable" and
+    "work-in-progress" records.
+* data_for_publication.csvs: Validates the "publishable" records after the
+    "data.csv" file has been filtered.
+
+The "csv-validator-docker" Docker image from
+<https://github.com/umd-lib/csv-validator-docker> is used to perform the actual
+validation. This Docker image uses the "csv-validator" tool
+(<http://digital-preservation.github.io/csv-validator/> )provided by
+The National Archives of the UK.
 
 ## Building the Docker Image
 
@@ -26,24 +61,38 @@ To run the freshly built Docker container on port 8983:
 > docker run -it --rm -p 8983:8983 docker.lib.umd.edu/solr-plant-patents
 ```
 
-## CSV Validation
+## Docker Build Stages
 
-The Docker image is created using a Docker multi-stage build. The first
-"validator" stage uses a "docker.lib.umd.edu/csv-validator" Docker image from
-<https://github.com/umd-lib/csv-validator-docker> as the base image.
+The Docker image is created using a Docker multi-stage build.
 
-This first stage uses the "data.csvs" CSV schema file to validate the "data.csv"
-file. If validation fails, the Docker build will terminate with an error message
-describing the validation failures.
+The following stages are used:
 
-If the validation stage is succesful, the second "builder" stage uses an
-official Solr Docker image as the base image to construct the
-"solr-plant-patents" Docker image.
+### "validator_data_csv" Stage
 
-See <http://digital-preservation.github.io/csv-validator/> for information about
-the validator tool, and
-<https://digital-preservation.github.io/csv-schema/csv-schema-1.1.html> for
-information about the CSV Schema.
+This stage uses the "docker.lib.umd.edu/csv-validator" Docker image
+to validate the raw "data.csv" file using the "data.csvs" CSV schema file. If
+the validation fails, the Docker build will halt with a validation error
+message.
+
+### "filter_for_publication" Stage
+
+This stage uses the "filter_for_publication" command from the
+"docker.lib.umd.edu/plant-patents-ingest" Docker image to
+filter the raw "data.csv" file, generating a "data_for_publication.csv"
+containing the records to include in the Solr core.
+
+### "validator_date_for_publication_csv" Stage
+
+This stage uses the "docker.lib.umd.edu/csv-validator" Docker image to validate
+the "data_for_publication.csv" file using the "data_for_publication.csvs" CSV
+schema file. If the validation fails, the Docker build will halt with a
+validation error message.
+
+### "builder" Stage
+
+This stage constructs the actual "solr-plant-patents" Docker image, starting
+with an official Solr Docker image as the base image the Solr core, and
+populating it with the data from the "data_for_publication.csv" file.
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -9,13 +9,27 @@ metadata from the Plant Patents Digitization Project.
 When making updates to the data or configuration, a new Docker image should be
 created.
 
+## Plant Patents Ingest Procedures
+
+The following procedures are intended to be performed by the "dpiprocessing"
+service account on the "libdpiprocessing.lib.umd.edu" server.
+
+The setup of the libdpiprocessing.lib.umd.edu server is outlined in
+<docs/procedures/libdpiprocessing_server_setup.md>.
+
+* [Add Plant Patent Scans](docs/procedures/Add_Plant_Patents_PDF_Scans.md)
+    Documents uploading new Plant Patents PDF scans provided by STEM into
+    fcrepo using the "libdpiprocessing" server, as well as updating the
+    "data.csv" file in the "solr-plant-patents" directory.
+
+* [Patents Metadata Update](docs/procedures/Patents_Metadata_Update.md)
+    Documents updating the "data.csv" in the "solr-plant-patents" directory
+    with changes from the "patents_metadata.csv" file provided by STEM.
+
 ## data.csv File
 
 The "data.csv" file contains both "publishable" and "work-in-progess" records
-derived from the Plant Patents metadata provided by STEM. See the
-"plant-patents-ingest" repository
-<https://github.com/umd-lib/plant-patents-ingest>) for information on generating
-this file.
+derived from the Plant Patents metadata provided by STEM.
 
 As part of the Docker build, the "work-in-progress" records will be filtered
 out (using the "filter_for_publication" command from "plant-patents-ingest"),

--- a/README.md
+++ b/README.md
@@ -11,19 +11,39 @@ created.
 
 ## Building the Docker Image
 
-When building the Docker image, the "data.csv" file will be used to populate the Solr database.
+When building the Docker image, the "data.csv" file will be used to populate the
+Solr database.
 
-To build the Docker image named "solr-plant-patents":
+To build the Docker image named "docker.lib.umd.edu/solr-plant-patents":
 
-```
-> docker build -t solr-plant-patents .
+```bash
+> docker build -t docker.lib.umd.edu/solr-plant-patents .
 ```
 
 To run the freshly built Docker container on port 8983:
 
+```bash
+> docker run -it --rm -p 8983:8983 docker.lib.umd.edu/solr-plant-patents
 ```
-> docker run -it --rm -p 8983:8983 solr-plant-patents
-```
+
+## CSV Validation
+
+The Docker image is created using a Docker multi-stage build. The first
+"validator" stage uses a "docker.lib.umd.edu/csv-validator" Docker image from
+<https://github.com/umd-lib/csv-validator-docker> as the base image.
+
+This first stage uses the "data.csvs" CSV schema file to validate the "data.csv"
+file. If validation fails, the Docker build will terminate with an error message
+describing the validation failures.
+
+If the validation stage is succesful, the second "builder" stage uses an
+official Solr Docker image as the base image to construct the
+"solr-plant-patents" Docker image.
+
+See <http://digital-preservation.github.io/csv-validator/> for information about
+the validator tool, and
+<https://digital-preservation.github.io/csv-schema/csv-schema-1.1.html> for
+information about the CSV Schema.
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -15,16 +15,16 @@ The following procedures are intended to be performed by the "dpiprocessing"
 service account on the "libdpiprocessing.lib.umd.edu" server.
 
 The setup of the libdpiprocessing.lib.umd.edu server is outlined in
-<docs/procedures/libdpiprocessing_server_setup.md>.
+[docs/procedures/libdpiprocessing_server_setup.md](docs/procedures/libdpiprocessing_server_setup.md)
 
-* [Add Plant Patent Scans](docs/procedures/Add_Plant_Patents_PDF_Scans.md)
-    Documents uploading new Plant Patents PDF scans provided by STEM into
-    fcrepo using the "libdpiprocessing" server, as well as updating the
-    "data.csv" file in the "solr-plant-patents" directory.
+* [Add Plant Patents PDF Scans](docs/procedures/Add_Plant_Patents_PDF_Scans.md) -
+Documents uploading new Plant Patents PDF scans provided by STEM into fcrepo
+using the "libdpiprocessing" server, as well as updating the "data.csv" file in
+the "solr-plant-patents" directory.
 
-* [Patents Metadata Update](docs/procedures/Patents_Metadata_Update.md)
-    Documents updating the "data.csv" in the "solr-plant-patents" directory
-    with changes from the "patents_metadata.csv" file provided by STEM.
+* [Patents Metadata Update](docs/procedures/Patents_Metadata_Update.md) -
+Documents updating the "data.csv" in the "solr-plant-patents" directory with
+changes from the "patents_metadata.csv" file provided by STEM.
 
 ## data.csv File
 

--- a/data.csvs
+++ b/data.csvs
@@ -1,19 +1,22 @@
-version 1.0
+version 1.1
 @totalColumns 17
-id: notEmpty unique positiveInteger
-patent_number:
-date:
-year:
+id: notEmpty unique regex("^PP\d\d\d\d\d$")
+patent_number: notEmpty unique regex("^PP\d\d\d\d\d$")
+// date must be empty, or "YYYY-MM-DD"
+date: empty or regex("\d\d\d\d-[01]\d-[0123]\d")
+year: empty or regex("\d\d\d\d")
 title:
-display_title:
+// display_title must be either "PP#####" or "PP##### -- <some text>"
+display_title: regex("^PP\d\d\d\d\d$") or regex("^PP\d\d\d\d\d -- .+$")
 large_category:
 inventor:
 city:
 state:
 country:
 uspc:
-image_url: notEmpty
+image_url:
 patent_url:
-scan_date:
+// scan_date must be empty, or "YYYY-MM-DD HH:mm:dd"
+scan_date: empty or regex("\d\d\d\d-[01]\d-[0123]\d [012]\d:[012345]\d:[012345]\d")
 pages:
 application_number:

--- a/data.csvs
+++ b/data.csvs
@@ -1,0 +1,19 @@
+version 1.0
+@totalColumns 17
+id: notEmpty unique positiveInteger
+patent_number:
+date:
+year:
+title:
+display_title:
+large_category:
+inventor:
+city:
+state:
+country:
+uspc:
+image_url: notEmpty
+patent_url:
+scan_date:
+pages:
+application_number:

--- a/data_for_publication.csvs
+++ b/data_for_publication.csvs
@@ -1,0 +1,22 @@
+version 1.1
+@totalColumns 17
+id: notEmpty unique regex("^PP\d\d\d\d\d$")
+patent_number: notEmpty unique regex("^PP\d\d\d\d\d$")
+// date must be empty, or "YYYY-MM-DD"
+date: empty or regex("\d\d\d\d-[01]\d-[0123]\d")
+year: empty or regex("\d\d\d\d")
+title:
+// display_title must be either "PP#####" or "PP##### -- <some text>"
+display_title: regex("^PP\d\d\d\d\d$") or regex("^PP\d\d\d\d\d -- .+$")
+large_category:
+inventor:
+city:
+state:
+country:
+uspc:
+image_url: notEmpty
+patent_url: notEmpty
+// scan_date must be "YYYY-MM-DD HH:mm:dd"
+scan_date: notEmpty regex("\d\d\d\d-[01]\d-[0123]\d [012]\d:[012345]\d:[012345]\d")
+pages: notEmpty
+application_number:

--- a/docs/procedures/Add_Plant_Patents_PDF_Scans.md
+++ b/docs/procedures/Add_Plant_Patents_PDF_Scans.md
@@ -1,0 +1,325 @@
+# Add Plant Patents PDF Scans
+
+This procedure is used for uploading new Plant Patents PDF scans into fcrepo,
+and updating the "data.csv" file in the "solr-plant-patents" repository.
+
+## Procedure Inputs/Outputs
+
+### Inputs
+
+* Patent scans are placed in "Plant Patents Digitization Project/PDFs" folder
+    in Box (<https://umd.app.box.com/folder/3598931071?s=yijnsgrz0v0jj1yuq09czqkfs9e83h5i>
+
+### Outputs
+
+* Patent scans have been uploaded to fcrepo
+* Patent scans have been placed in the
+    "/processing/processing/archelon/plantpatents/binaries" directory on the
+    libdpiprocessing.lib.umd.edu server.
+* The “data.csv” file in solr-plant-patents has been updated.
+
+## Docker Images
+
+The following Docker images are used by this procedure:
+
+* docker.lib.umd.edu/csv-validator:1.1.5-umd-0
+* docker.lib.umd.edu/plant-patents-ingest:1.0.0
+* docker.lib.umd.edu/plastrond:3.6.0rc6
+* bitnami/rclone:1.57.0
+
+Thee Docker images should be available in the UMD Nexus prior to running
+this procedure.
+
+## Prerequisites
+
+### Pre.1) Create Box access token
+
+The following procedure uses "rclone" to retrieve files from Box. An access
+token is needed to authorize "rclone" to access Box. To obtain an access token:
+
+Pre. 1.1) On a local workstation, go to
+    <https://github.com/rclone/rclone/releases/tag/v1.57.0> and download the
+    appropiate Zip file for your operating system. For Mac OS, this will be
+    "rclone-v1.57.0-osx-amd64.zip".
+
+Pre. 1.2) Unzip the downloaded file
+
+Pre. 1.3) Switch into the "rclone" directory, and run the following command:
+
+    ```bash
+    ./rclone authorize "box"
+    ```
+
+    A web browser will open, and display a Box login page. On the login page,
+    left-click "Use Single Sign On (SSO)" link, and fill out the resulting page
+    with your UMD email address. Then left-click the "Authorize" button.
+
+Pre. 1.4) After completing the login, a page indicating that read/write access
+    to your Box account is being provided to "rclone". Left-click the
+    "Grant access to Box" button.
+
+Pre. 1.5) In the terminal, an access token will be printed:
+
+    ```text
+    Paste the following into your remote machine --->
+    {"access_token":...}
+    <---End paste
+    ```
+
+    Copy the `{"access_token":...}` line. This will be referred to as
+    as `<BOX_ACCESS_TOKEN>` in the steps below.
+
+### Pre.2) Create an fcrepo access token
+
+Pre. 2.1) In a web browser on the local workstation, generate an fcrepo JWT
+    access token by going to:
+
+    <https://fcrepo.lib.umd.edu/fcrepo/user/token?subject=plastron&role=fedoraAdmin>
+
+    This will be referred to as `<FCREPO_ACCESS_TOKEN>` in the steps below.
+
+## Procedure
+
+### 1) Log in to libdpiprocessing and switch service account
+
+1.1) SSH to the "libdpiprocessing" server:
+
+    ```bash
+    ssh libdpiprocessing.lib.umd.edu
+    ```
+
+1.2) Switch to the "dpiprocessing" service account:
+
+    ```bash
+    su - dpiprocessing
+    ```
+
+### 2) Set up the environment variables
+
+2.1) Export a "BASE_DIR" environment variable as the base of the Plant Patents
+    directory hierarchy on the server
+
+    ```bash
+    export BASE_DIR=/home/dpiprocessing/plant_patents
+    ```
+
+2.2) Export a "BOX_BASE_DIR" environment variable containing the base
+    Plant Patents directory on Box:
+
+    ```bash
+    export BOX_BASE_DIR="/Plant Patents Digitization Project"
+    ```
+
+2.3) Export an "ARCHIVE_BINARIES_DIR" environment variable containing the
+    directory where Plant Patents PDF scans are permanently stored:
+
+    ```bash
+    export ARCHIVE_BINARIES_DIR="/processing/processing/archelon/plantpatents/binaries/"
+    ```
+
+2.4) Create a "BOX_ACCESS_TOKEN" environment variable where
+    `<BOX_ACCESS_TOKEN>` is the Box access token from the prerequisites:
+
+    ```bash
+    export BOX_ACCESS_TOKEN='<BOX_ACCESS_TOKEN>'
+    ```
+
+### 3) Create Docker aliases
+
+3.1) Run the following commands to create aliases to simplify the running of the
+    commands:
+
+    ```bash
+    alias rclone_docker='docker run --rm --user `id -u`:`id -g` --env BOX_BASE_DIR="$BOX_BASE_DIR" --volume "$BASE_DIR/docker_mount":/tmp/host bitnami/rclone:1.57.0 --box-token "$BOX_ACCESS_TOKEN"'
+
+    alias ingest_docker='docker run --rm --user `id -u`:`id -g` --env BOX_BASE_DIR="$BOX_BASE_DIR" --volume "$BASE_DIR/docker_mount":/tmp/host --volume "$ARCHIVE_BINARIES_DIR":/tmp/archive_binaries docker.lib.umd.edu/plant-patents-ingest:1.0.0'
+
+    alias plastron_docker='docker run --rm --entrypoint "plastron" --user `id -u`:`id -g` --env BOX_BASE_DIR="$BOX_BASE_DIR" --volume "$BASE_DIR/docker_mount":/tmp/host docker.lib.umd.edu/plastrond:3.6.0rc6'
+
+    alias validator_docker='docker run --rm --volume "$BASE_DIR/docker_mount":/tmp/host docker.lib.umd.edu/csv-validator:1.1.5-umd-0'
+    ```
+
+### 3) Ensure solr-plant-patents repository is at the latest version
+
+4.1) Switch to the "$BASE_DIR/solr-plant-patents" directory:
+
+    ```bash
+    cd "$BASE_DIR/docker_mount/solr-plant-patents"
+    ```
+
+4.2) Use Git to checkout the "main" branch, and a "git pull" to ensure
+    repository is up-to-date:
+
+    ```bash
+    git checkout main
+    git pull
+    ```
+
+### 5) Retrieve the Plant Patents PDF scans from Box
+
+5.1) Sync the Plant Patents PDF scans from the "PDFs/" directory on Box using
+    "rclone":
+
+    ```bash
+    rclone_docker --progress sync :box:"$BOX_BASE_DIR"/PDFs /tmp/host/box/PDFs
+    ```
+
+### 6) Upload Plant Patents PDF scans to fcrepo using Plastron
+
+6.1) Run the "create_plastron_batch" command to generate the
+    "plastron_batch.csv" file:
+
+    ```bash
+    ingest_docker create_plastron_batch --root-dir /tmp/host/box/PDFs --output-file /tmp/host/plastron/plastron_batch.csv
+    ```
+
+6.2) Switch to the "$BASE_DIR/docker_mount/plastron" directory:
+
+    ```bash
+    cd "$BASE_DIR/docker_mount/plastron"
+    ```
+
+6.4) Create a "config/fcrepo.yml" Plastron configuration file:
+
+    ```bash
+    mkdir config
+    vi config/fcrepo.yml
+    ```
+
+    with the following contents:
+
+    ```
+    REPOSITORY:
+        REST_ENDPOINT: https://fcrepo.lib.umd.edu/fcrepo/rest
+        RELPATH: /pcdm
+        AUTH_TOKEN: <FCREPO_ACCESS_TOKEN>
+        LOG_DIR: /tmp/host/plastron/logs/
+    ```
+
+    where `<FCREPO_ACCESS_TOKEN>` is the JWT access token from the previous
+    steps.
+
+6.5) Load the Plant Patents PDF scans listed in the "plastron_batch.csv" file
+    using the Plastron "stub" command:
+
+    ```
+    plastron_docker --config /tmp/host/plastron/config/fcrepo.yml stub \
+        --identifier-column patent_number \
+        --binary-column filepath \
+        --rename-binary-column image_url \
+        --member-of https://fcrepo.lib.umd.edu/fcrepo/rest/pcdm/db/c7/f3/44/dbc7f344-c0fa-49c9-af29-37270fa185c8 \
+        --access umdaccess:Public \
+        --container /pcdm \
+        --output-file /tmp/host/solr-plant-patents/fcrepo_urls.csv \
+        /tmp/host/plastron/plastron_batch.csv
+    ```
+
+    **Note**: In the above the "--member-of" URL is the URL of the
+    "Plant Patents Image Database" collection in fcrepo.
+
+### 7) Extract the file metadata from the downloaded PDFs
+
+7.1) Run the "extract_binaries_metadata" command to create the
+    "files_metadata.csv" file:
+
+    ```bash
+    ingest_docker extract_binaries_metadata \
+        --root-dir /tmp/host/box/PDFs \
+        --output-file /tmp/host/solr-plant-patents/file_metadata.csv
+    ```
+
+### 8) Create the "scans_metadata.csv" file
+
+8.1) Run the "csvjoin" command to merge the "fcrepo_urls.csv" and
+    "files_metadata.csv" file into a "scans_metadata.csv" file:
+
+    ```bash
+    ingest_docker csvjoin --no-inference --left --columns "patent_number" \
+        /tmp/host/solr-plant-patents/file_metadata.csv \
+        /tmp/host/solr-plant-patents/fcrepo_urls.csv >  \
+        "$BASE_DIR/docker_mount/solr-plant-patents/scans_metadata.csv"
+    ```
+
+### 9) Merge the "scans_metadata.csv" file into "data.csv"
+
+9.1) Using the "merge_csv" tool from "umd-lib/plant-patents-ingest", merge
+     the "scans_metadata.csv" file into the "data.csv" file, generating a
+     "data_updated.csv" file:
+
+    ```bash
+    ingest_docker merge_csv \
+        --base-file /tmp/host/solr-plant-patents/data.csv \
+        --merge-file /tmp/host/solr-plant-patents/scans_metadata.csv \
+        --output-file /tmp/host/solr-plant-patents/data_updated.csv
+    ```
+
+### 10) Update the derived Solr fields
+
+10.1) Using the "derive_solr_fields" tool, derive the various Solr fields from
+     "data_updated.csv" file, creating a "data_updated_derived.csv file":
+
+    ```bash
+    ingest_docker derive_solr_fields \
+        --source-file /tmp/host/solr-plant-patents/data_updated.csv \
+        --output-file /tmp/host/solr-plant-patents/data_updated_derived.csv
+    ```
+
+### 11) Replace the "data.csv" file
+
+11.1) Rename the "data_updated_derived.csv" file to "data.csv":
+
+    ```bash
+    mv "$BASE_DIR/docker_mount/solr-plant-patents/data_updated_derived.csv" \
+       "$BASE_DIR/docker_mount/solr-plant-patents/data.csv"
+    ```
+
+### 12) Move the Plant Patents PDF scans to archive storage
+
+12.1) Run the "organize_files" command to move the uploaded Plant Patents PDF
+    scans to the "/tmp/archive_binaries" directory:
+
+    ```bash
+    ingest_docker organize_files \
+        --source-directory /tmp/host/box/PDFs \
+        --destination-directory /tmp/archive_binaries
+    ```
+
+### 13) Validate the "data.csv" file
+
+13.1) Switch to the "$BASE_DIR/docker_mount/solr-plant-patents" directory:
+
+    ```bash
+    cd "$BASE_DIR/docker_mount/solr-plant-patents"
+    ```
+
+13.2) Run the "csv-validator" Docker image:
+
+    ```bash
+    validator_docker validate \
+        /tmp/host/solr-plant-patents/data.csv \
+        /tmp/host/solr-plant-patents/data.csvs
+    ```
+
+    Any validation errors will be displayed, otherwise "PASS" will be output.
+
+    **Note:** Validation errors indicate a problem with either the source data
+    or some other issue, which will need to be corrected before going on to the
+    next step.
+
+13.3) Commit the changes in the "data.csv" file to the "solr-plant-patents":
+
+    ```bash
+    git add data.csv
+    git commit
+    ```
+
+    **Note:** The "fcrepo_urls.csv", "file_metadata.csv", and
+    "scans_metadata.csv", should *not* be committed.
+
+13.4) Delete the temporary working files:
+
+    ```bash
+    rm fcrepo_urls.csv
+    rm file_metadata.csv
+    rm scans_metadata.csv
+    ```

--- a/docs/procedures/Add_Plant_Patents_PDF_Scans.md
+++ b/docs/procedures/Add_Plant_Patents_PDF_Scans.md
@@ -39,44 +39,44 @@ token is needed to authorize "rclone" to access Box. To obtain an access token:
 
 Pre. 1.1) On a local workstation, go to
     <https://github.com/rclone/rclone/releases/tag/v1.57.0> and download the
-    appropiate Zip file for your operating system. For Mac OS, this will be
+    appropriate Zip file for your operating system. For Mac OS, this will be
     "rclone-v1.57.0-osx-amd64.zip".
 
 Pre. 1.2) Unzip the downloaded file
 
 Pre. 1.3) Switch into the "rclone" directory, and run the following command:
 
-    ```bash
-    ./rclone authorize "box"
-    ```
+```bash
+./rclone authorize "box"
+```
 
-    A web browser will open, and display a Box login page. On the login page,
-    left-click "Use Single Sign On (SSO)" link, and fill out the resulting page
-    with your UMD email address. Then left-click the "Authorize" button.
+A web browser will open, and display a Box login page. On the login page,
+left-click "Use Single Sign On (SSO)" link, and fill out the resulting page
+with your UMD email address. Then left-click the "Authorize" button.
 
 Pre. 1.4) After completing the login, a page indicating that read/write access
-    to your Box account is being provided to "rclone". Left-click the
-    "Grant access to Box" button.
+to your Box account is being provided to "rclone". Left-click the
+"Grant access to Box" button.
 
 Pre. 1.5) In the terminal, an access token will be printed:
 
-    ```text
-    Paste the following into your remote machine --->
-    {"access_token":...}
-    <---End paste
-    ```
+```text
+Paste the following into your remote machine --->
+{"access_token":...}
+<---End paste
+```
 
-    Copy the `{"access_token":...}` line. This will be referred to as
-    as `<BOX_ACCESS_TOKEN>` in the steps below.
+Copy the `{"access_token":...}` line. This will be referred to as
+`<BOX_ACCESS_TOKEN>` in the steps below.
 
 ### Pre.2) Create an fcrepo access token
 
 Pre. 2.1) In a web browser on the local workstation, generate an fcrepo JWT
-    access token by going to:
+access token by going to:
 
-    <https://fcrepo.lib.umd.edu/fcrepo/user/token?subject=plastron&role=fedoraAdmin>
+<https://fcrepo.lib.umd.edu/fcrepo/user/token?subject=plastron&role=fedoraAdmin>
 
-    This will be referred to as `<FCREPO_ACCESS_TOKEN>` in the steps below.
+This will be referred to as `<FCREPO_ACCESS_TOKEN>` in the steps below.
 
 ## Procedure
 
@@ -84,242 +84,241 @@ Pre. 2.1) In a web browser on the local workstation, generate an fcrepo JWT
 
 1.1) SSH to the "libdpiprocessing" server:
 
-    ```bash
-    ssh libdpiprocessing.lib.umd.edu
-    ```
+```bash
+ssh libdpiprocessing.lib.umd.edu
+```
 
 1.2) Switch to the "dpiprocessing" service account:
 
-    ```bash
-    su - dpiprocessing
-    ```
+```bash
+su - dpiprocessing
+```
 
 ### 2) Set up the environment variables
 
 2.1) Export a "BASE_DIR" environment variable as the base of the Plant Patents
-    directory hierarchy on the server
+directory hierarchy on the server:
 
-    ```bash
-    export BASE_DIR=/home/dpiprocessing/plant_patents
-    ```
+```bash
+export BASE_DIR=/home/dpiprocessing/plant_patents
+```
 
 2.2) Export a "BOX_BASE_DIR" environment variable containing the base
-    Plant Patents directory on Box:
+Plant Patents directory on Box:
 
-    ```bash
-    export BOX_BASE_DIR="/Plant Patents Digitization Project"
-    ```
+```bash
+export BOX_BASE_DIR="/Plant Patents Digitization Project"
+```
 
 2.3) Export an "ARCHIVE_BINARIES_DIR" environment variable containing the
-    directory where Plant Patents PDF scans are permanently stored:
+directory where Plant Patents PDF scans are permanently stored:
 
-    ```bash
-    export ARCHIVE_BINARIES_DIR="/processing/processing/archelon/plantpatents/binaries/"
-    ```
+```bash
+export ARCHIVE_BINARIES_DIR="/processing/processing/archelon/plantpatents/binaries/"
+```
 
-2.4) Create a "BOX_ACCESS_TOKEN" environment variable where
-    `<BOX_ACCESS_TOKEN>` is the Box access token from the prerequisites:
+2.4) Create a "BOX_ACCESS_TOKEN" environment variable where `<BOX_ACCESS_TOKEN>`
+is the Box access token from the prerequisites:
 
-    ```bash
-    export BOX_ACCESS_TOKEN='<BOX_ACCESS_TOKEN>'
-    ```
+```bash
+export BOX_ACCESS_TOKEN='<BOX_ACCESS_TOKEN>'
+```
 
 ### 3) Create Docker aliases
 
 3.1) Run the following commands to create aliases to simplify the running of the
-    commands:
+commands:
 
-    ```bash
-    alias rclone_docker='docker run --rm --user `id -u`:`id -g` --env BOX_BASE_DIR="$BOX_BASE_DIR" --volume "$BASE_DIR/docker_mount":/tmp/host bitnami/rclone:1.57.0 --box-token "$BOX_ACCESS_TOKEN"'
+```bash
+alias rclone_docker='docker run --rm --user `id -u`:`id -g` --env BOX_BASE_DIR="$BOX_BASE_DIR" --volume "$BASE_DIR/docker_mount":/tmp/host bitnami/rclone:1.57.0 --box-token "$BOX_ACCESS_TOKEN"'
 
-    alias ingest_docker='docker run --rm --user `id -u`:`id -g` --env BOX_BASE_DIR="$BOX_BASE_DIR" --volume "$BASE_DIR/docker_mount":/tmp/host --volume "$ARCHIVE_BINARIES_DIR":/tmp/archive_binaries docker.lib.umd.edu/plant-patents-ingest:1.0.0'
+alias ingest_docker='docker run --rm --user `id -u`:`id -g` --env BOX_BASE_DIR="$BOX_BASE_DIR" --volume "$BASE_DIR/docker_mount":/tmp/host --volume "$ARCHIVE_BINARIES_DIR":/tmp/archive_binaries docker.lib.umd.edu/plant-patents-ingest:1.0.0'
 
-    alias plastron_docker='docker run --rm --entrypoint "plastron" --user `id -u`:`id -g` --env BOX_BASE_DIR="$BOX_BASE_DIR" --volume "$BASE_DIR/docker_mount":/tmp/host docker.lib.umd.edu/plastrond:3.6.0rc6'
+alias plastron_docker='docker run --rm --entrypoint "plastron" --user `id -u`:`id -g` --env BOX_BASE_DIR="$BOX_BASE_DIR" --volume "$BASE_DIR/docker_mount":/tmp/host docker.lib.umd.edu/plastrond:3.6.0rc6'
 
-    alias validator_docker='docker run --rm --volume "$BASE_DIR/docker_mount":/tmp/host docker.lib.umd.edu/csv-validator:1.1.5-umd-0'
-    ```
+alias validator_docker='docker run --rm --volume "$BASE_DIR/docker_mount":/tmp/host docker.lib.umd.edu/csv-validator:1.1.5-umd-0'
+```
 
 ### 3) Ensure solr-plant-patents repository is at the latest version
 
 4.1) Switch to the "$BASE_DIR/solr-plant-patents" directory:
 
-    ```bash
-    cd "$BASE_DIR/docker_mount/solr-plant-patents"
-    ```
+```bash
+cd "$BASE_DIR/docker_mount/solr-plant-patents"
+```
 
 4.2) Use Git to checkout the "main" branch, and a "git pull" to ensure
-    repository is up-to-date:
+repository is up-to-date:
 
-    ```bash
-    git checkout main
-    git pull
-    ```
+```bash
+git checkout main
+git pull
+```
 
 ### 5) Retrieve the Plant Patents PDF scans from Box
 
 5.1) Sync the Plant Patents PDF scans from the "PDFs/" directory on Box using
-    "rclone":
+"rclone":
 
-    ```bash
-    rclone_docker --progress sync :box:"$BOX_BASE_DIR"/PDFs /tmp/host/box/PDFs
-    ```
+```bash
+rclone_docker --progress sync :box:"$BOX_BASE_DIR"/PDFs /tmp/host/box/PDFs
+```
 
 ### 6) Upload Plant Patents PDF scans to fcrepo using Plastron
 
 6.1) Run the "create_plastron_batch" command to generate the
-    "plastron_batch.csv" file:
+"plastron_batch.csv" file:
 
-    ```bash
-    ingest_docker create_plastron_batch --root-dir /tmp/host/box/PDFs --output-file /tmp/host/plastron/plastron_batch.csv
-    ```
+```bash
+ingest_docker create_plastron_batch --root-dir /tmp/host/box/PDFs --output-file /tmp/host/plastron/plastron_batch.csv
+```
 
 6.2) Switch to the "$BASE_DIR/docker_mount/plastron" directory:
 
-    ```bash
-    cd "$BASE_DIR/docker_mount/plastron"
-    ```
+```bash
+cd "$BASE_DIR/docker_mount/plastron"
+```
 
 6.4) Create a "config/fcrepo.yml" Plastron configuration file:
 
-    ```bash
-    mkdir config
-    vi config/fcrepo.yml
-    ```
+```bash
+mkdir config
+vi config/fcrepo.yml
+```
 
-    with the following contents:
+with the following contents:
 
-    ```
-    REPOSITORY:
-        REST_ENDPOINT: https://fcrepo.lib.umd.edu/fcrepo/rest
-        RELPATH: /pcdm
-        AUTH_TOKEN: <FCREPO_ACCESS_TOKEN>
-        LOG_DIR: /tmp/host/plastron/logs/
-    ```
+```text
+REPOSITORY:
+    REST_ENDPOINT: https://fcrepo.lib.umd.edu/fcrepo/rest
+    RELPATH: /pcdm
+    AUTH_TOKEN: <FCREPO_ACCESS_TOKEN>
+    LOG_DIR: /tmp/host/plastron/logs/
+```
 
-    where `<FCREPO_ACCESS_TOKEN>` is the JWT access token from the previous
-    steps.
+where `<FCREPO_ACCESS_TOKEN>` is the JWT access token from the previous steps.
 
 6.5) Load the Plant Patents PDF scans listed in the "plastron_batch.csv" file
-    using the Plastron "stub" command:
+using the Plastron "stub" command:
 
-    ```
-    plastron_docker --config /tmp/host/plastron/config/fcrepo.yml stub \
-        --identifier-column patent_number \
-        --binary-column filepath \
-        --rename-binary-column image_url \
-        --member-of https://fcrepo.lib.umd.edu/fcrepo/rest/pcdm/db/c7/f3/44/dbc7f344-c0fa-49c9-af29-37270fa185c8 \
-        --access umdaccess:Public \
-        --container /pcdm \
-        --output-file /tmp/host/solr-plant-patents/fcrepo_urls.csv \
-        /tmp/host/plastron/plastron_batch.csv
-    ```
+```bash
+plastron_docker --config /tmp/host/plastron/config/fcrepo.yml stub \
+    --identifier-column patent_number \
+    --binary-column filepath \
+    --rename-binary-column image_url \
+    --member-of https://fcrepo.lib.umd.edu/fcrepo/rest/pcdm/db/c7/f3/44/dbc7f344-c0fa-49c9-af29-37270fa185c8 \
+    --access umdaccess:Public \
+    --container /pcdm \
+    --output-file /tmp/host/solr-plant-patents/fcrepo_urls.csv \
+    /tmp/host/plastron/plastron_batch.csv
+```
 
-    **Note**: In the above the "--member-of" URL is the URL of the
-    "Plant Patents Image Database" collection in fcrepo.
+**Note**: In the above the "--member-of" URL is the URL of the
+"Plant Patents Image Database" collection in fcrepo.
 
 ### 7) Extract the file metadata from the downloaded PDFs
 
 7.1) Run the "extract_binaries_metadata" command to create the
-    "files_metadata.csv" file:
+"files_metadata.csv" file:
 
-    ```bash
-    ingest_docker extract_binaries_metadata \
-        --root-dir /tmp/host/box/PDFs \
-        --output-file /tmp/host/solr-plant-patents/file_metadata.csv
-    ```
+```bash
+ingest_docker extract_binaries_metadata \
+    --root-dir /tmp/host/box/PDFs \
+    --output-file /tmp/host/solr-plant-patents/file_metadata.csv
+```
 
 ### 8) Create the "scans_metadata.csv" file
 
 8.1) Run the "csvjoin" command to merge the "fcrepo_urls.csv" and
-    "files_metadata.csv" file into a "scans_metadata.csv" file:
+"files_metadata.csv" file into a "scans_metadata.csv" file:
 
-    ```bash
-    ingest_docker csvjoin --no-inference --left --columns "patent_number" \
-        /tmp/host/solr-plant-patents/file_metadata.csv \
-        /tmp/host/solr-plant-patents/fcrepo_urls.csv >  \
-        "$BASE_DIR/docker_mount/solr-plant-patents/scans_metadata.csv"
-    ```
+```bash
+ingest_docker csvjoin --no-inference --left --columns "patent_number" \
+    /tmp/host/solr-plant-patents/file_metadata.csv \
+    /tmp/host/solr-plant-patents/fcrepo_urls.csv >  \
+    "$BASE_DIR/docker_mount/solr-plant-patents/scans_metadata.csv"
+```
 
 ### 9) Merge the "scans_metadata.csv" file into "data.csv"
 
 9.1) Using the "merge_csv" tool from "umd-lib/plant-patents-ingest", merge
-     the "scans_metadata.csv" file into the "data.csv" file, generating a
-     "data_updated.csv" file:
+  the "scans_metadata.csv" file into the "data.csv" file, generating a
+  "data_updated.csv" file:
 
-    ```bash
-    ingest_docker merge_csv \
-        --base-file /tmp/host/solr-plant-patents/data.csv \
-        --merge-file /tmp/host/solr-plant-patents/scans_metadata.csv \
-        --output-file /tmp/host/solr-plant-patents/data_updated.csv
-    ```
+```bash
+ingest_docker merge_csv \
+    --base-file /tmp/host/solr-plant-patents/data.csv \
+    --merge-file /tmp/host/solr-plant-patents/scans_metadata.csv \
+    --output-file /tmp/host/solr-plant-patents/data_updated.csv
+```
 
 ### 10) Update the derived Solr fields
 
 10.1) Using the "derive_solr_fields" tool, derive the various Solr fields from
-     "data_updated.csv" file, creating a "data_updated_derived.csv file":
+"data_updated.csv" file, creating a "data_updated_derived.csv file":
 
-    ```bash
-    ingest_docker derive_solr_fields \
-        --source-file /tmp/host/solr-plant-patents/data_updated.csv \
-        --output-file /tmp/host/solr-plant-patents/data_updated_derived.csv
-    ```
+```bash
+ingest_docker derive_solr_fields \
+    --source-file /tmp/host/solr-plant-patents/data_updated.csv \
+    --output-file /tmp/host/solr-plant-patents/data_updated_derived.csv
+```
 
 ### 11) Replace the "data.csv" file
 
 11.1) Rename the "data_updated_derived.csv" file to "data.csv":
 
-    ```bash
-    mv "$BASE_DIR/docker_mount/solr-plant-patents/data_updated_derived.csv" \
-       "$BASE_DIR/docker_mount/solr-plant-patents/data.csv"
-    ```
+```bash
+mv "$BASE_DIR/docker_mount/solr-plant-patents/data_updated_derived.csv" \
+    "$BASE_DIR/docker_mount/solr-plant-patents/data.csv"
+```
 
 ### 12) Move the Plant Patents PDF scans to archive storage
 
 12.1) Run the "organize_files" command to move the uploaded Plant Patents PDF
-    scans to the "/tmp/archive_binaries" directory:
+scans to the "/tmp/archive_binaries" directory:
 
-    ```bash
-    ingest_docker organize_files \
-        --source-directory /tmp/host/box/PDFs \
-        --destination-directory /tmp/archive_binaries
-    ```
+```bash
+ingest_docker organize_files \
+    --source-directory /tmp/host/box/PDFs \
+    --destination-directory /tmp/archive_binaries
+```
 
 ### 13) Validate the "data.csv" file
 
 13.1) Switch to the "$BASE_DIR/docker_mount/solr-plant-patents" directory:
 
-    ```bash
-    cd "$BASE_DIR/docker_mount/solr-plant-patents"
-    ```
+```bash
+cd "$BASE_DIR/docker_mount/solr-plant-patents"
+```
 
 13.2) Run the "csv-validator" Docker image:
 
-    ```bash
-    validator_docker validate \
-        /tmp/host/solr-plant-patents/data.csv \
-        /tmp/host/solr-plant-patents/data.csvs
-    ```
+```bash
+validator_docker validate \
+    /tmp/host/solr-plant-patents/data.csv \
+    /tmp/host/solr-plant-patents/data.csvs
+```
 
-    Any validation errors will be displayed, otherwise "PASS" will be output.
+Any validation errors will be displayed, otherwise "PASS" will be output.
 
-    **Note:** Validation errors indicate a problem with either the source data
-    or some other issue, which will need to be corrected before going on to the
-    next step.
+**Note:** Validation errors indicate a problem with either the source data
+or some other issue, which will need to be corrected before going on to the
+next step.
 
 13.3) Commit the changes in the "data.csv" file to the "solr-plant-patents":
 
-    ```bash
-    git add data.csv
-    git commit
-    ```
+```bash
+git add data.csv
+git commit
+```
 
-    **Note:** The "fcrepo_urls.csv", "file_metadata.csv", and
-    "scans_metadata.csv", should *not* be committed.
+**Note:** The "fcrepo_urls.csv", "file_metadata.csv", and "scans_metadata.csv",
+should *not* be committed.
 
 13.4) Delete the temporary working files:
 
-    ```bash
-    rm fcrepo_urls.csv
-    rm file_metadata.csv
-    rm scans_metadata.csv
-    ```
+```bash
+rm fcrepo_urls.csv
+rm file_metadata.csv
+rm scans_metadata.csv
+```

--- a/docs/procedures/Patents_Metadata_Update.md
+++ b/docs/procedures/Patents_Metadata_Update.md
@@ -1,0 +1,227 @@
+# Patents Metadata Update
+
+This procedure is used merge updates to the "patents_metadata.csv" file in Box
+into the "data.csv" file in the "solr-plant-patents" repository.
+
+## Procedure Inputs/Outputs
+
+### Inputs
+
+* The "patents_metadata.csv" file (<https://umd.app.box.com/file/907935674011>)
+    in the "Plant Patents Digitization Project/Metadata" folder
+    (<https://umd.app.box.com/folder/3603951785>) has been updated.
+
+### Outputs
+
+* The “data.csv” file in solr-plant-patents has been updated.
+
+## Docker Images
+
+The following Docker images are used by this procedure:
+
+* docker.lib.umd.edu/csv-validator:1.1.5-umd-0
+* docker.lib.umd.edu/plant-patents-ingest:1.0.0
+* bitnami/rclone:1.57.0
+
+These Docker images should be available in the UMD Nexus prior to running
+this procedure.
+
+## Prerequisites
+
+### Pre.1) Create Box access token
+
+The following procedure uses "rclone" to retrieve files from Box. An access
+token is needed to authorize "rclone" to access Box. To obtain an access token:
+
+Pre. 1.1) On a local workstation, go to
+    <https://github.com/rclone/rclone/releases/tag/v1.57.0> and download the
+    appropiate Zip file for your operating system. For Mac OS, this will be
+    "rclone-v1.57.0-osx-amd64.zip".
+
+Pre. 1.2) Unzip the downloaded file
+
+Pre. 1.3) Switch into the "rclone" directory, and run the following command:
+
+    ```bash
+    ./rclone authorize "box"
+    ```
+
+    A web browser will open, and display a Box login page. On the login page,
+    left-click "Use Single Sign On (SSO)" link, and fill out the resulting page
+    with your UMD email address. Then left-click the "Authorize" button.
+
+Pre. 1.4) After completing the login, a page indicating that read/write access
+    to your Box account is being provided to "rclone". Left-click the
+    "Grant access to Box" button.
+
+Pre. 1.5) In the terminal, an access token will be printed:
+
+    ```text
+    Paste the following into your remote machine --->
+    {"access_token":...}
+    <---End paste
+    ```
+
+    Copy the `{"access_token":...}` line. This will be referred to as
+    as `<BOX_ACCESS_TOKEN>` in the steps below.
+
+## Procedure
+
+### 1) Log in to libdpiprocessing and switch service account
+
+1.1) SSH to the "libdpiprocessing" server:
+
+    ```bash
+    ssh libdpiprocessing.lib.umd.edu
+    ```
+
+1.2) Switch to the "dpiprocessing" service account:
+
+    ```bash
+    su - dpiprocessing
+    ```
+
+### 2) Set up the environment variables
+
+2.1) Export a "BASE_DIR" environment variable as the base of the Plant Patents
+    directory hierarchy on the server
+
+    ```bash
+    export BASE_DIR=/home/dpiprocessing/plant_patents
+    ```
+
+2.2) Export a "BOX_BASE_DIR" environment variable containing the base
+    Plant Patents directory on Box:
+
+    ```bash
+    export BOX_BASE_DIR="/Plant Patents Digitization Project"
+    ```
+
+### 3) Create Docker aliases
+
+3.1) Run the following commands to create aliases to simplify the running of the
+    commands:
+
+    ```bash
+    alias rclone_docker='docker run --rm --user `id -u`:`id -g` --env BOX_BASE_DIR="$BOX_BASE_DIR" --volume "$BASE_DIR/docker_mount":/tmp/host bitnami/rclone:1.57.0 --box-token "$BOX_ACCESS_TOKEN"'
+
+    alias ingest_docker='docker run --rm --user `id -u`:`id -g` --env BOX_BASE_DIR="$BOX_BASE_DIR" --volume "$BASE_DIR/docker_mount":/tmp/host docker.lib.umd.edu/plant-patents-ingest:1.0.0'
+
+    alias validator_docker='docker run --rm --volume "$BASE_DIR/docker_mount":/tmp/host docker.lib.umd.edu/csv-validator:1.1.5-umd-0'
+    ```
+
+### 4) Ensure solr-plant-patents repository is at the latest version
+
+4.1) Switch to the "$BASE_DIR/solr-plant-patents" directory:
+
+    ```bash
+    cd "$BASE_DIR/docker_mount/solr-plant-patents"
+    ```
+
+4.2) Use Git to checkout the "main" branch, and a "git pull" to ensure
+    repository is up-to-date:
+
+    ```bash
+    git checkout main
+    git pull
+    ```
+
+### 5) Retrieve the "patents_metadata.csv" CSV file from Box
+
+5.1) Sync the "patents_metadata.csv" file from Box:
+
+    ```bash
+    rclone_docker sync  --progress :box:"$BOX_BASE_DIR"/Metadata/patents_metadata.csv /tmp/host/box/metadata
+    ```
+
+### 6) Validate the "patents_metadata.csv" file
+
+6.1) Run the "csv-validator" Docker image:
+
+    ```bash
+    validator_docker validate \
+        /tmp/host/box/metadata/patents_metadata.csv \
+        /tmp/host/solr-plant-patents/patents_metadata.csvs
+    ```
+
+    Any validation errors will be displayed, otherwise "PASS" will be output.
+
+    **Note:** Validation errors should be reported back to STEM, and corrected
+    before going on to the next step.
+
+### 9) Merge the "patents_metadata.csv" file into "data.csv"
+
+9.1) Using the "merge_csv" tool from "umd-lib/plant-patents-ingest", merge
+     the "scans_metadata.csv" file into the "data.csv" file, generating a
+     "data_updated.csv" file:
+
+    ```bash
+    ingest_docker merge_csv \
+              --base-file /tmp/host/solr-plant-patents/data.csv \
+              --merge-file /tmp/host/box/metadata/patents_metadata.csv \
+              --skip-validation \
+              --output-file /tmp/host/solr-plant-patents/data_updated.csv
+    ```
+
+    **Note:** "--skip-validation" flag is used because the
+    "patents_metadata.csv" file is a "source of truth", so any differences are
+    resolved in favor of that file.
+
+### 10) Update the derived Solr fields
+
+10.1) Using the "derive_solr_fields" tool, derive the various Solr fields from
+     "data_updated.csv" file, creating a "data_updated_derived.csv file":
+
+    ```bash
+    ingest_docker derive_solr_fields \
+        --source-file /tmp/host/solr-plant-patents/data_updated.csv \
+        --output-file /tmp/host/solr-plant-patents/data_updated_derived.csv
+    ```
+
+### 11) Replace the "data.csv" file
+
+11.1) Rename the "data_updated_derived.csv" file to "data.csv":
+
+    ```bash
+    mv $BASE_DIR/docker_mount/solr-plant-patents/data_updated_derived.csv $BASE_DIR/docker_mount/solr-plant-patents/data.csv
+    ```
+
+### 13) Validate the "data.csv" file
+
+13.1) Switch to the "$BASE_DIR/docker_mount/solr-plant-patents" directory:
+
+    ```bash
+    cd $BASE_DIR/docker_mount/solr-plant-patents
+    ```
+
+13.2) Run the "csv-validator" Docker image:
+
+    ```bash
+    validator_docker validate \
+        /tmp/host/solr-plant-patents/data.csv \
+        /tmp/host/solr-plant-patents/data.csvs
+    ```
+
+    Any validation errors will be displayed, otherwise "PASS" will be output.
+
+    **Note:** Validation errors indicate a problem with either the source data
+    or some other issue, which will need to be corrected before going on to the
+    next step.
+
+13.3) Commit the changes in the "data.csv" file to the "solr-plant-patents":
+
+    ```bash
+    git add data.csv
+    git commit
+    ```
+
+    **Note:** The "fcrepo_urls.csv", "file_metadata.csv", and
+    "scans_metadata.csv", should *not* be committed.
+
+13.4) Delete the temporary working files:
+
+    ```bash
+    rm fcrepo_urls.csv
+    rm file_metadata.csv
+    rm scans_metadata.csv
+    ```

--- a/docs/procedures/Patents_Metadata_Update.md
+++ b/docs/procedures/Patents_Metadata_Update.md
@@ -8,8 +8,8 @@ into the "data.csv" file in the "solr-plant-patents" repository.
 ### Inputs
 
 * The "patents_metadata.csv" file (<https://umd.app.box.com/file/907935674011>)
-    in the "Plant Patents Digitization Project/Metadata" folder
-    (<https://umd.app.box.com/folder/3603951785>) has been updated.
+in the "Plant Patents Digitization Project/Metadata" folder
+(<https://umd.app.box.com/folder/3603951785>) has been updated.
 
 ### Outputs
 
@@ -34,36 +34,36 @@ The following procedure uses "rclone" to retrieve files from Box. An access
 token is needed to authorize "rclone" to access Box. To obtain an access token:
 
 Pre. 1.1) On a local workstation, go to
-    <https://github.com/rclone/rclone/releases/tag/v1.57.0> and download the
-    appropiate Zip file for your operating system. For Mac OS, this will be
-    "rclone-v1.57.0-osx-amd64.zip".
+<https://github.com/rclone/rclone/releases/tag/v1.57.0> and download the
+appropriate Zip file for your operating system. For Mac OS, this will be
+"rclone-v1.57.0-osx-amd64.zip".
 
 Pre. 1.2) Unzip the downloaded file
 
 Pre. 1.3) Switch into the "rclone" directory, and run the following command:
 
-    ```bash
-    ./rclone authorize "box"
-    ```
+```bash
+./rclone authorize "box"
+```
 
-    A web browser will open, and display a Box login page. On the login page,
-    left-click "Use Single Sign On (SSO)" link, and fill out the resulting page
-    with your UMD email address. Then left-click the "Authorize" button.
+A web browser will open, and display a Box login page. On the login page,
+left-click "Use Single Sign On (SSO)" link, and fill out the resulting page
+with your UMD email address. Then left-click the "Authorize" button.
 
 Pre. 1.4) After completing the login, a page indicating that read/write access
-    to your Box account is being provided to "rclone". Left-click the
-    "Grant access to Box" button.
+to your Box account is being provided to "rclone". Left-click the
+"Grant access to Box" button.
 
 Pre. 1.5) In the terminal, an access token will be printed:
 
-    ```text
-    Paste the following into your remote machine --->
-    {"access_token":...}
-    <---End paste
-    ```
+```text
+Paste the following into your remote machine --->
+{"access_token":...}
+<---End paste
+```
 
-    Copy the `{"access_token":...}` line. This will be referred to as
-    as `<BOX_ACCESS_TOKEN>` in the steps below.
+Copy the `{"access_token":...}` line. This will be referred to as
+`<BOX_ACCESS_TOKEN>` in the steps below.
 
 ## Procedure
 
@@ -71,157 +71,157 @@ Pre. 1.5) In the terminal, an access token will be printed:
 
 1.1) SSH to the "libdpiprocessing" server:
 
-    ```bash
-    ssh libdpiprocessing.lib.umd.edu
-    ```
+```bash
+ssh libdpiprocessing.lib.umd.edu
+```
 
 1.2) Switch to the "dpiprocessing" service account:
 
-    ```bash
-    su - dpiprocessing
-    ```
+```bash
+su - dpiprocessing
+```
 
 ### 2) Set up the environment variables
 
 2.1) Export a "BASE_DIR" environment variable as the base of the Plant Patents
-    directory hierarchy on the server
+directory hierarchy on the server:
 
-    ```bash
-    export BASE_DIR=/home/dpiprocessing/plant_patents
-    ```
+```bash
+export BASE_DIR=/home/dpiprocessing/plant_patents
+```
 
 2.2) Export a "BOX_BASE_DIR" environment variable containing the base
     Plant Patents directory on Box:
 
-    ```bash
-    export BOX_BASE_DIR="/Plant Patents Digitization Project"
-    ```
+```bash
+export BOX_BASE_DIR="/Plant Patents Digitization Project"
+```
 
 ### 3) Create Docker aliases
 
 3.1) Run the following commands to create aliases to simplify the running of the
-    commands:
+commands:
 
-    ```bash
-    alias rclone_docker='docker run --rm --user `id -u`:`id -g` --env BOX_BASE_DIR="$BOX_BASE_DIR" --volume "$BASE_DIR/docker_mount":/tmp/host bitnami/rclone:1.57.0 --box-token "$BOX_ACCESS_TOKEN"'
+```bash
+alias rclone_docker='docker run --rm --user `id -u`:`id -g` --env BOX_BASE_DIR="$BOX_BASE_DIR" --volume "$BASE_DIR/docker_mount":/tmp/host bitnami/rclone:1.57.0 --box-token "$BOX_ACCESS_TOKEN"'
 
-    alias ingest_docker='docker run --rm --user `id -u`:`id -g` --env BOX_BASE_DIR="$BOX_BASE_DIR" --volume "$BASE_DIR/docker_mount":/tmp/host docker.lib.umd.edu/plant-patents-ingest:1.0.0'
+alias ingest_docker='docker run --rm --user `id -u`:`id -g` --env BOX_BASE_DIR="$BOX_BASE_DIR" --volume "$BASE_DIR/docker_mount":/tmp/host docker.lib.umd.edu/plant-patents-ingest:1.0.0'
 
-    alias validator_docker='docker run --rm --volume "$BASE_DIR/docker_mount":/tmp/host docker.lib.umd.edu/csv-validator:1.1.5-umd-0'
-    ```
+alias validator_docker='docker run --rm --volume "$BASE_DIR/docker_mount":/tmp/host docker.lib.umd.edu/csv-validator:1.1.5-umd-0'
+```
 
 ### 4) Ensure solr-plant-patents repository is at the latest version
 
 4.1) Switch to the "$BASE_DIR/solr-plant-patents" directory:
 
-    ```bash
-    cd "$BASE_DIR/docker_mount/solr-plant-patents"
-    ```
+```bash
+cd "$BASE_DIR/docker_mount/solr-plant-patents"
+```
 
 4.2) Use Git to checkout the "main" branch, and a "git pull" to ensure
-    repository is up-to-date:
+repository is up-to-date:
 
-    ```bash
-    git checkout main
-    git pull
-    ```
+```bash
+git checkout main
+git pull
+```
 
 ### 5) Retrieve the "patents_metadata.csv" CSV file from Box
 
 5.1) Sync the "patents_metadata.csv" file from Box:
 
-    ```bash
-    rclone_docker sync  --progress :box:"$BOX_BASE_DIR"/Metadata/patents_metadata.csv /tmp/host/box/metadata
-    ```
+```bash
+rclone_docker sync  --progress :box:"$BOX_BASE_DIR"/Metadata/patents_metadata.csv /tmp/host/box/metadata
+```
 
 ### 6) Validate the "patents_metadata.csv" file
 
 6.1) Run the "csv-validator" Docker image:
 
-    ```bash
-    validator_docker validate \
-        /tmp/host/box/metadata/patents_metadata.csv \
-        /tmp/host/solr-plant-patents/patents_metadata.csvs
-    ```
+```bash
+validator_docker validate \
+    /tmp/host/box/metadata/patents_metadata.csv \
+    /tmp/host/solr-plant-patents/patents_metadata.csvs
+```
 
-    Any validation errors will be displayed, otherwise "PASS" will be output.
+Any validation errors will be displayed, otherwise "PASS" will be output.
 
-    **Note:** Validation errors should be reported back to STEM, and corrected
-    before going on to the next step.
+**Note:** Validation errors should be reported back to STEM, and corrected
+before going on to the next step.
 
 ### 9) Merge the "patents_metadata.csv" file into "data.csv"
 
 9.1) Using the "merge_csv" tool from "umd-lib/plant-patents-ingest", merge
-     the "scans_metadata.csv" file into the "data.csv" file, generating a
-     "data_updated.csv" file:
+  the "scans_metadata.csv" file into the "data.csv" file, generating a
+  "data_updated.csv" file:
 
-    ```bash
-    ingest_docker merge_csv \
-              --base-file /tmp/host/solr-plant-patents/data.csv \
-              --merge-file /tmp/host/box/metadata/patents_metadata.csv \
-              --skip-validation \
-              --output-file /tmp/host/solr-plant-patents/data_updated.csv
-    ```
+```bash
+ingest_docker merge_csv \
+          --base-file /tmp/host/solr-plant-patents/data.csv \
+          --merge-file /tmp/host/box/metadata/patents_metadata.csv \
+          --skip-validation \
+          --output-file /tmp/host/solr-plant-patents/data_updated.csv
+```
 
-    **Note:** "--skip-validation" flag is used because the
-    "patents_metadata.csv" file is a "source of truth", so any differences are
-    resolved in favor of that file.
+**Note:** "--skip-validation" flag is used because the
+"patents_metadata.csv" file is a "source of truth", so any differences are
+resolved in favor of that file.
 
 ### 10) Update the derived Solr fields
 
 10.1) Using the "derive_solr_fields" tool, derive the various Solr fields from
-     "data_updated.csv" file, creating a "data_updated_derived.csv file":
+"data_updated.csv" file, creating a "data_updated_derived.csv file":
 
-    ```bash
-    ingest_docker derive_solr_fields \
-        --source-file /tmp/host/solr-plant-patents/data_updated.csv \
-        --output-file /tmp/host/solr-plant-patents/data_updated_derived.csv
-    ```
+```bash
+ingest_docker derive_solr_fields \
+    --source-file /tmp/host/solr-plant-patents/data_updated.csv \
+    --output-file /tmp/host/solr-plant-patents/data_updated_derived.csv
+```
 
 ### 11) Replace the "data.csv" file
 
 11.1) Rename the "data_updated_derived.csv" file to "data.csv":
 
-    ```bash
-    mv $BASE_DIR/docker_mount/solr-plant-patents/data_updated_derived.csv $BASE_DIR/docker_mount/solr-plant-patents/data.csv
-    ```
+```bash
+mv $BASE_DIR/docker_mount/solr-plant-patents/data_updated_derived.csv $BASE_DIR/docker_mount/solr-plant-patents/data.csv
+```
 
 ### 13) Validate the "data.csv" file
 
 13.1) Switch to the "$BASE_DIR/docker_mount/solr-plant-patents" directory:
 
-    ```bash
-    cd $BASE_DIR/docker_mount/solr-plant-patents
-    ```
+```bash
+cd $BASE_DIR/docker_mount/solr-plant-patents
+```
 
 13.2) Run the "csv-validator" Docker image:
 
-    ```bash
-    validator_docker validate \
-        /tmp/host/solr-plant-patents/data.csv \
-        /tmp/host/solr-plant-patents/data.csvs
-    ```
+```bash
+validator_docker validate \
+    /tmp/host/solr-plant-patents/data.csv \
+    /tmp/host/solr-plant-patents/data.csvs
+```
 
-    Any validation errors will be displayed, otherwise "PASS" will be output.
+Any validation errors will be displayed, otherwise "PASS" will be output.
 
-    **Note:** Validation errors indicate a problem with either the source data
-    or some other issue, which will need to be corrected before going on to the
-    next step.
+**Note:** Validation errors indicate a problem with either the source data
+or some other issue, which will need to be corrected before going on to the
+next step.
 
 13.3) Commit the changes in the "data.csv" file to the "solr-plant-patents":
 
-    ```bash
-    git add data.csv
-    git commit
-    ```
+```bash
+git add data.csv
+git commit
+```
 
-    **Note:** The "fcrepo_urls.csv", "file_metadata.csv", and
-    "scans_metadata.csv", should *not* be committed.
+**Note:** The "fcrepo_urls.csv", "file_metadata.csv", and "scans_metadata.csv",
+should *not* be committed.
 
 13.4) Delete the temporary working files:
 
-    ```bash
-    rm fcrepo_urls.csv
-    rm file_metadata.csv
-    rm scans_metadata.csv
-    ```
+```bash
+rm fcrepo_urls.csv
+rm file_metadata.csv
+rm scans_metadata.csv
+```

--- a/docs/procedures/libdpiprocessing_server_setup.md
+++ b/docs/procedures/libdpiprocessing_server_setup.md
@@ -1,0 +1,85 @@
+# Setup - libdpiprocessing Server
+
+## Introduction
+
+This document describes the setup of the "dpiprocessing" service account on the
+"libdpiprocessing.lib.umd.edu" server for use in the Plant Patents Ingest
+process.
+
+## Applications Prerequsites
+
+* Git
+* Docker
+
+The "docker-ce" and "docker-compose" clients should be loaded, and be usable by
+the "dpiprocessing" service account.
+
+## Git Repository Access Setup
+
+### Git Repository Access
+
+1) In the "dpiprocessing" service account, create a public/private keypair:
+
+```bash
+> su - dpiprocessing
+> ssh-keygen -t rsa
+(Just hit "Enter" to accept all the defaults. This created "~/.ssh/id_rsa" and
+"~/.ssh/id_rsa.pub" files).
+```
+
+2) Add public key to "lib-ssdr-service" account on GitHib.
+
+3) In the "dpiprocessing" service account home directory, edit the ".bashrc"
+and add a "git_authors.sh" file as outlined in
+<https://confluence.umd.edu/display/~mohideen/Git+Service+Account+Commits>
+
+## "plant_patents" subdirectory Setup
+
+The following steps creates the following subdirectory hierarchy in the
+"dpiprocessing" service account home directory ("/home/dpiprocessing/"):
+
+```text
+plant_patents/
+  |-- docker_mount/
+       |-- box/
+       |    |-- metadata (directory holding "patents_metadata.csv" from Box
+       |    |-- PDFs (directory holding Plant Patents PDF scans from Box)
+       |
+       |-- plastron/ (directory to hold Plastron configuration file and logs)
+       |-- solr-plant-patents/ (clone of the "solr-plant-patents" GitHub repository)
+```
+
+1) SSH to the "libdpiprocessing" server:
+
+    ```bash
+    ssh libdpiprocessing.lib.umd.edu
+    ```
+
+2) Switch to the "dpiprocessing" service account:
+
+    ```bash
+    su - dpiprocessing
+    ```
+
+3) Switch to the "dpiprocessing" service account home directory:
+
+    ```bash
+    cd ~
+    ```
+
+4) Construct the directories:
+
+    ```bash
+    mkdir plant_patents
+    mkdir -p plant_patents/docker_mount/box/metadata
+    mkdir -p plant_patents/docker_mount/box/PDFs
+    mkdir -p plant_patents/plastron
+    ```
+
+5) Switch to the "plant_patents/docker_mount" directory and clone the
+    "umd-lib/solr-plant-patents" GitHub repository:
+
+    ```bash
+    cd plant_patents/docker_mount
+    git clone git@github.com:umd-lib/solr-plant-patents.git
+    ```

--- a/docs/procedures/libdpiprocessing_server_setup.md
+++ b/docs/procedures/libdpiprocessing_server_setup.md
@@ -51,35 +51,35 @@ plant_patents/
 
 1) SSH to the "libdpiprocessing" server:
 
-    ```bash
-    ssh libdpiprocessing.lib.umd.edu
-    ```
+```bash
+ssh libdpiprocessing.lib.umd.edu
+```
 
 2) Switch to the "dpiprocessing" service account:
 
-    ```bash
-    su - dpiprocessing
-    ```
+```bash
+su - dpiprocessing
+```
 
 3) Switch to the "dpiprocessing" service account home directory:
 
-    ```bash
-    cd ~
-    ```
+```bash
+cd ~
+```
 
 4) Construct the directories:
 
-    ```bash
-    mkdir plant_patents
-    mkdir -p plant_patents/docker_mount/box/metadata
-    mkdir -p plant_patents/docker_mount/box/PDFs
-    mkdir -p plant_patents/plastron
-    ```
+```bash
+mkdir plant_patents
+mkdir -p plant_patents/docker_mount/box/metadata
+mkdir -p plant_patents/docker_mount/box/PDFs
+mkdir -p plant_patents/plastron
+```
 
 5) Switch to the "plant_patents/docker_mount" directory and clone the
-    "umd-lib/solr-plant-patents" GitHub repository:
+"umd-lib/solr-plant-patents" GitHub repository:
 
-    ```bash
-    cd plant_patents/docker_mount
-    git clone git@github.com:umd-lib/solr-plant-patents.git
-    ```
+```bash
+cd plant_patents/docker_mount
+git clone git@github.com:umd-lib/solr-plant-patents.git
+```

--- a/patents_metadata.csvs
+++ b/patents_metadata.csvs
@@ -1,0 +1,20 @@
+version 1.1
+@totalColumns 17
+patent_number: notEmpty unique regex("^PP\d\d\d\d\d$")
+// date must be empty, or "YYYY-MM-DD"
+date: empty or regex("\d\d\d\d-[01]\d-[0123]\d")
+title:
+large_category:
+inventor:
+city:
+state:
+country:
+uspc:
+application_number:
+application_date:
+application_year:
+assignee:
+assignee_city:
+assignee_state:
+assignee_country:
+notes:


### PR DESCRIPTION
Modified the repository to support the new Plant Patents update process.

Changes include:

* The "data.csv" file now includes publishable and "work-in-progress" data. When generating the Docker image, the "data.csv" file is filtered so that only publishable records are included.
* Added CSV Schema files to validate CSV file used in updating the "data.csv" file.
* Modifications to the Docker build to validate the CSV files being processed
* Added "procedures" documentation on how to update the "data.csv" file when new Patent Scans or metadata are provided.

**Note:** This pull request incorporates the changes in Pull Request #3

https://issues.umd.edu/browse/LIBFCREPO-1072